### PR TITLE
merge development branch into main

### DIFF
--- a/flixel_5_3_1/ParallaxSprite.hx
+++ b/flixel_5_3_1/ParallaxSprite.hx
@@ -142,6 +142,8 @@ class ParallaxSprite extends FlxSprite
 		}
 
 		getScreenPosition(_point, camera).subtractPoint(offset);
+		if (isPixelPerfectRender(camera))
+			_point.floor();
 		_matrix.tx += _point.x;
 		_matrix.ty += _point.y;
 

--- a/flixel_5_3_1/ParallaxSprite.hx
+++ b/flixel_5_3_1/ParallaxSprite.hx
@@ -72,6 +72,24 @@ class ParallaxSprite extends FlxSprite {
 		pointTwo.scrollFactor.set(scrollTwoX, scrollTwoY);
 		return this;
 	}
+	override public function getScreenBounds(?newRect:FlxRect, ?camera:FlxCamera):FlxRect
+	{
+		if (newRect == null)
+			newRect = FlxRect.get();
+
+		if (camera == null)
+			camera = FlxG.camera;
+
+		newRect.setPosition(x, y);
+		if (pixelPerfectPosition)
+			newRect.floor();
+		newRect.x += -Std.int(camera.scroll.x * scrollFactor.x) - offset.x + origin.x;
+		newRect.y += -Std.int(camera.scroll.y * scrollFactor.y) - offset.y + origin.y;
+		if (isPixelPerfectRender(camera))
+			newRect.floor();
+		newRect.setSize(frameWidth * _matrix.a, frameHeight * _matrix.d);
+		return newRect.getRotatedBounds(angle, _scaledOrigin, newRect);
+	}
 
 	override public function destroy():Void {
 		pointOne = null;
@@ -87,7 +105,6 @@ class ParallaxSprite extends FlxSprite {
 		_frame.prepareMatrix(_matrix, FlxFrameAngle.ANGLE_0, checkFlipX(), checkFlipY());
 		updateScrollMatrix();
 		_matrix.translate(-origin.x, -origin.y);
-		_matrix.scale(scale.x, scale.y);
 
 		if (bakedRotationAngle <= 0) {
 			updateTrig();
@@ -116,10 +133,10 @@ class ParallaxSprite extends FlxSprite {
 
 		if (direction == HORIZONTAL) {
 			_matrix.c = (_bufferTwo.x - _bufferOne.x) / frameHeight;
-			scale.y = (_bufferTwo.y - _bufferOne.y) / frameHeight;
+			_matrix.d = (_bufferTwo.y - _bufferOne.y) / frameHeight;
 		} else if (direction == VERTICAL) {
 			_matrix.b = (_bufferTwo.y - _bufferOne.y) / frameWidth;
-			scale.x = (_bufferTwo.x - _bufferOne.x) / frameWidth;
+			_matrix.a = (_bufferTwo.x - _bufferOne.x) / frameWidth;
 		}
 	}
 }

--- a/flixel_5_3_1/ParallaxSprite.hx
+++ b/flixel_5_3_1/ParallaxSprite.hx
@@ -48,11 +48,9 @@ class ParallaxSprite extends FlxSprite
 	 * @param   X			The ParallaxSprite's initial X position.
 	 * @param   Y			The ParllaxSprite's initial Y position.
 	 */
-	public function new(graphic:FlxGraphicAsset, x:Float = 0, y:Float = 0)
+	public function new(x:Float = 0, y:Float = 0, graphic:FlxGraphicAsset)
 	{
-		super(x, y);
-		loadGraphic(graphic);
-		antialiasing = ClientPrefs.globalAntialiasing;
+		super(x, y. graphic);
 		origin.set(0, 0);
 	}
 


### PR DESCRIPTION
This pull brings parity to ParallaxSprites with haxeflixel 4's render pipeline, fixes a screenspace bug where ParallaxSprites would pop into and out of view, updates the existing documentation, and improves performance by directly editing matrix values, avoiding function calls, and cancelling the origin out.